### PR TITLE
Update README and add Dockerfiles

### DIFF
--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -1,0 +1,7 @@
+FROM golang:1.13
+
+WORKDIR /dkvs
+COPY . .
+
+RUN apt-get update && apt-get install -y protobuf-compiler
+RUN make

--- a/Dockerfile_client
+++ b/Dockerfile_client
@@ -1,0 +1,5 @@
+FROM dkvs-base:latest
+
+WORKDIR /dkvs
+
+CMD ["bin/client"]

--- a/Dockerfile_follower
+++ b/Dockerfile_follower
@@ -1,0 +1,5 @@
+FROM dkvs-base:latest
+
+WORKDIR /dkvs
+
+CMD ["bin/follower"]

--- a/Dockerfile_leader
+++ b/Dockerfile_leader
@@ -1,0 +1,5 @@
+FROM dkvs-base:latest
+
+WORKDIR /dkvs
+
+CMD ["bin/leader"]

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
-PROTOC_GEN_GO := $(GOPATH)/bin/protoc-gen-go
-PROTOC := $(shell which protoc)
-
+.PHONY: default
 default: build
 
-$(PROTOC_GEN_GO):
-	go get -u github.com/golang/protobuf/protoc-gen-go
-
-protos: $(wildcard protos/*) $(PROTOC_GEN_GO) $(PROTOC)
+# Just rebuild the protos each time, it's basically instant and keeps the rule
+# simple.
+.PHONY: protos
+protos:
 	protoc -I protos protos/leader/leader.proto --go_out=plugins=grpc:protos/leader
 	protoc -I protos protos/follower/follower.proto --go_out=plugins=grpc:protos/follower
 	protoc -I protos protos/config/config.proto --go_out=plugins=grpc:protos/config 
@@ -25,8 +23,33 @@ bin/follower: $(FOLLOWER) $(CONFIG) protos
 bin/client: $(CLIENT) $(CONFIG) protos
 	go build -o bin/client client/client.go
 
+.PHONY: build
 build: bin/leader bin/follower bin/client
 
+.PHONY: clean
 clean:
-	rm -rf bin; rm -f protos/*/*.pb.go
+	-rm -rf bin
+	-rm -f protos/*/*.pb.go
 
+#
+# Docker rules.
+#
+
+.PHONY: docker
+docker: docker-leader docker-follower docker-client
+
+.PHONY: docker-leader
+docker-leader: docker-base
+	docker build -f Dockerfile_leader -t dkvs-leader .
+
+.PHONY: docker-follower
+docker-follower: docker-base
+	docker build -f Dockerfile_follower -t dkvs-follower .
+
+.PHONY: docker-client
+docker-client: docker-base
+	docker build -f Dockerfile_client -t dkvs-client .
+
+.PHONY: docker-base
+docker-base:
+	docker build -f Dockerfile_base -t dkvs-base .

--- a/README.md
+++ b/README.md
@@ -1,17 +1,37 @@
 # distributed-key-value-store
 A highly available distributed key value store.
 
+There are 3 processes:
+
+* **leader** - waits for the sync signal from the followers and sends back sync
+  responses.
+* **follower** - listens to port 10000 for incoming client requests and
+  periodically syncs up with the leader.
+* **client** - a test client sending request to a follower. Start the test
+  client with default port, 10000.
+
 # Prerequisites
-1. Clone the repository under `$GOPATH/src`
 
-1. Install dependencies (may need more)
-```bash
-go get google.golang.org/grpc
-go get -u github.com/golang/protobuf/protoc-gen-go
-go get github.com/google/uuid
-```
+To run in docker, skip to [running with docker](#running-with-docker).
 
-1. You can try doing ```make``` to build the project. If not:
+1. Install [the protobuf compiler](https://github.com/protocolbuffers/protobuf/releases).
+
+2. Install [the Go protobuf plugin](https://developers.google.com/protocol-buffers/docs/gotutorial#compiling-your-protocol-buffers)
+
+3. Make sure your path includes `$GOPATH/bin` (`$HOME/go/bin` by default).
+
+4. The default configration is in `protos/config/local-config.pb.txt`; you can
+   use your own config file to set a different port for example.
+
+# Building and Running
+
+## Using `make`
+
+1. Run `make` to build the project.
+
+2. Binaries are in bin/.
+
+## Manually 
 
 1. Generate proto files
 ```
@@ -20,24 +40,19 @@ protoc -I protos protos/leader/leader.proto --go_out=plugins=grpc:protos/leader
 protoc -I protos protos/config/config.proto --go_out=plugins=grpc:protos/config
 ```
 
-## Start components
-
-1. The leader waits for the sync signal from the followers and sends back sync responses.
-Start the leader:
+2. You can start each process with `go run`:
 ```bash
 go run leader/leader.go
-```
-
-2. Follower listens to port 10000 for incoming client requests and periodically syncs up with the leader.
-Start the follower:
-```bash
 go run follower/follower.go
-```
-
-3. Start a test client sending request to a follower.
-Start the test client with default port, 10000
-```bash
 go run client/client.go
 ```
 
-4. The default configration is in `config/local-config.pb.txt`; you can use your own config file to set a different port for example.
+# Running with Docker
+
+1. Run `make docker` to build the three docker images: `dkvs-leader`,
+   `dkvs-follower`, and `dkvs-client`.
+
+2. Run them with docker, for example:
+```bash
+docker run --rm --network host dkvs-leader
+```

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/google/uuid v1.1.1
 	google.golang.org/grpc v1.29.1
+	google.golang.org/protobuf v1.23.0
 )


### PR DESCRIPTION
- Add docker for each of our 3 binaries. This is slight overkill, but
  should make testing with cloud services easer (and make it easier for
  anyone else wishing to run hermetically).
- Makefile: remove PROTOC_GEN_GO and PROTOC, which both broke when I
  puleld the repo.
- Makefile: add PHONY, change clean syntax.
- Readme: split into prereqs and running
- Readme: instructions to install protoc and protoc-gen-go.