### PR TITLE
simplify to use the pre-defined env int follower_id in the communicat…

### DIFF
--- a/leader/leader.go
+++ b/leader/leader.go
@@ -52,7 +52,8 @@ func (l *leader) Sync(ctx context.Context, req *pb.SyncRequest) (*pb.SyncRespons
 		Result:  "TBD",
 		TargetFollowers: []*pb.TargetFollower{
 			{
-				Address: req.Address,
+				Address:    req.Address,
+				FollowerId: req.FollowerId,
 			},
 		},
 	}

--- a/protos/leader/leader.proto
+++ b/protos/leader/leader.proto
@@ -11,15 +11,16 @@ service Leader {
 message SyncRequest {
     string key = 1;
     string address = 2;
-    string followerID = 3;
+    int32 follower_id = 3;
 }
 
 message SyncResponse {
     string result = 1;
     int64 version = 2;
-    repeated TargetFollower targetFollowers= 3;
+    repeated TargetFollower targetFollowers = 3;
 }
 
 message TargetFollower {
     string address = 1;
+    int32 follower_id = 2;
 }


### PR DESCRIPTION
…ion; so every components can refer to the pre-defined env to find out the other participants.