### PR TITLE
Send UpdateReqest concurrently

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -18,7 +18,7 @@ import (
 var (
 	followerID = flag.String("follower_id", "", "The Follower to talk to")
 
-	testKeys = []string{"key-0", "Key-1", "Key-2", "Key-3", "key-4", "key-5", "key-6", "key-7", "key-8", "key-9"}
+	testKeys = []string{"key-0", "key-1", "key-2", "key-3", "key-4", "key-5", "key-6", "key-7", "key-8", "key-9"}
 )
 
 // sentRequest

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/leader/leader.go
+++ b/leader/leader.go
@@ -40,7 +40,7 @@ func newLeader(configuration *cpb.Configuration) *leader {
 }
 
 func (l *leader) Update(ctx context.Context, req *pb.UpdateRequest) (*pb.UpdateResponse, error) {
-	log.Printf("leader received sync request %v", req)
+	log.Printf("leader received update request %v", req)
 	l.keyVersionMap.m.Lock()
 	defer l.keyVersionMap.m.Unlock()
 	if l.keyVersionMap.data[req.Key] == nil {
@@ -65,7 +65,7 @@ func (l *leader) Update(ctx context.Context, req *pb.UpdateRequest) (*pb.UpdateR
 			FollowerId: backupFollowerID,
 		},
 	}
-	log.Printf("leader replying sync response %v", resp)
+	log.Printf("leader replying udpate response %v", resp)
 	return resp, nil
 }
 


### PR DESCRIPTION
Follower sends UdpateRequest to Leader concurrently and asynchronously.

Each key will have au update channel so that different keys will be updated concurrently. 

But the update of the same key now is not concurrently because the linearizable consideration.