### PR TITLE
Implement broadcasts from the leader to followers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,14 @@ protos/config/config.pb.go: protos/config/config.proto
 # dependncies of each binary target.
 #
 
-bin/leader: FORCE protos/config/config.pb.go protos/leader/leader.pb.go
-	go build -o bin/leader leader/leader.go
+bin/leader: FORCE protos/config/config.pb.go protos/leader/leader.pb.go protos/follower/follower.pb.go
+	go build -o bin/leader distributed-key-value-store/leader
 
 bin/follower: FORCE protos/config/config.pb.go protos/leader/leader.pb.go protos/follower/follower.pb.go
-	go build -o bin/follower follower/follower.go
+	go build -o bin/follower distributed-key-value-store/follower
 
 bin/client: FORCE protos/config/config.pb.go protos/follower/follower.pb.go
-	go build -o bin/client client/client.go
+	go build -o bin/client distributed-key-value-store/client
 
 .PHONY: build
 build: bin/leader bin/follower bin/client

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ protoc -I protos protos/config/config.proto --go_out=plugins=grpc:protos/config
 
 2. You can start each process with `go run`:
 ```bash
-go run leader/leader.go
-go run follower/follower.go
-go run client/client.go
+go run distributed-key-value-store/leader
+go run distributed-key-value-storeer/follower
+go run distributed-key-value-store/client
 ```
 
 # Running with Docker

--- a/leader/broadcaster.go
+++ b/leader/broadcaster.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"google.golang.org/grpc"
+
+	cpb "distributed-key-value-store/protos/config"
+	fpb "distributed-key-value-store/protos/follower"
+	pb "distributed-key-value-store/protos/leader"
+)
+
+var frequencyMS = flag.Int("frequency", 1000, "The frequency of periodic broadcasts in milliseconds")
+
+type broadcaster interface {
+	// Asynchrounously enqueue and update to be broadcasted. When it is sent
+	// depends in the implementer - it is only guaranteed to be sent eventually.
+	enqueue(key string, resp *pb.UpdateResponse)
+}
+
+// immediateCaster asynchronously broadcasts updates as soon as possible. Useful
+// for debugging and latency-sensitive data.
+//
+// Should be created with newImmediate.
+type immediateCaster struct {
+	notifier
+}
+
+func newImmediate(config *cpb.Configuration) (*immediateCaster, error) {
+	notifier, err := newNotifier(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &immediateCaster{
+		notifier: notifier,
+	}, nil
+}
+
+func (ic *immediateCaster) enqueue(key string, resp *pb.UpdateResponse) {
+	ic.notify(key, resp)
+}
+
+// periodicCaster broadcasts at a regular interval.
+//
+// Should be created with newPeriodic.
+type periodicCaster struct {
+	notifier
+	// TODO: Unused.
+	done chan bool
+	// Updates holds the list of updates that will be broadcast at the next
+	// interval. Rather than a buffered channel of updates, a channel holding a
+	// slice lets the slice grow unbounded.
+	updates chan []update
+}
+
+type update struct {
+	key  string
+	resp *pb.UpdateResponse
+}
+
+func newPeriodic(config *cpb.Configuration) (*periodicCaster, error) {
+	// Connect to each follower.
+	notifier, err := newNotifier(config)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := periodicCaster{
+		notifier: notifier,
+		done:     make(chan bool),
+		updates:  make(chan []update, 1),
+	}
+	pc.updates <- nil
+
+	// Kick off a goroutine that wakes up periodically and sends updates.
+	go func() {
+		ticker := time.NewTicker(time.Duration(*frequencyMS) * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-pc.done:
+				log.Printf("Periodic broadcaster done.")
+				return
+			case <-ticker.C:
+				// This has a bit of a "stop-the-world" problem, as incoming updates
+				// will block until we launch len(updates) goroutines.
+				updates := <-pc.updates
+				for _, update := range updates {
+					pc.notify(update.key, update.resp)
+				}
+				pc.updates <- nil
+			}
+		}
+	}()
+
+	return &pc, nil
+}
+
+func (pc *periodicCaster) enqueue(key string, resp *pb.UpdateResponse) {
+	updates := <-pc.updates
+	updates = append(updates, update{key: key, resp: resp})
+	pc.updates <- updates
+}
+
+// notifier knows how to connect to and notify all the followers in a config.
+//
+// Should only be created with newNotifier.
+type notifier struct {
+	// followers maps a follower ID to it's GRPC client.
+	// TODO: Call Close() on all clients.
+	followers map[string]fpb.FollowerClient
+}
+
+func newNotifier(config *cpb.Configuration) (notifier, error) {
+	// Establish a GRPC client for each follower.
+	notifier := notifier{
+		followers: make(map[string]fpb.FollowerClient),
+	}
+	for id, addr := range config.FollowerAddresses {
+		conn, err := grpc.Dial(addr, grpc.WithInsecure())
+		if err != nil {
+			return notifier, fmt.Errorf("failed to dial follower %q at address %q: %v", id, addr, err)
+		}
+		notifier.followers[id] = fpb.NewFollowerClient(conn)
+	}
+	return notifier, nil
+}
+
+// Asynchrounously send an RPC to every follower (except the one the response is
+// already being sent to).
+func (nt notifier) notify(key string, resp *pb.UpdateResponse) {
+	for id, client := range nt.followers {
+		// We don't have to broadcast the update to the updater.
+		if resp.PrePrimary.FollowerId == id {
+			continue
+		}
+		go func(id string, client fpb.FollowerClient) {
+			req := fpb.NotifyRequest{
+				Key: key,
+			}
+			// TODO: Handle.
+			_, err := client.Notify(context.Background(), &req)
+			if err != nil {
+				log.Printf("error notifying follower %q", id)
+				return
+			}
+			log.Printf("notified follower %q", id)
+		}(id, client)
+	}
+
+}

--- a/protos/config/config.proto
+++ b/protos/config/config.proto
@@ -9,5 +9,6 @@ message Configuration {
     // TODO: maybe host and port need to be in separate fields
     string leader_address = 1;
 
+    // Maps each follower's ID to its address.
     map<string, string> follower_addresses = 2;
 }

--- a/protos/follower/follower.proto
+++ b/protos/follower/follower.proto
@@ -11,9 +11,12 @@ service Follower {
     // Get the value for a key. Only sent by clients.
     rpc Get(GetRequest) returns (GetResponse) {}
 
-    // Contact another follower to sync up values for a key. Only sent by the
-    // leader.
+    // Sync up values for a key. Only sent by other followers.
     rpc Sync(SyncRequest) returns (SyncResponse) {}
+
+    // Notify the follower that a key has been updated, and it should sync with
+    // another follower for the update. Only sent by the leader.
+    rpc Notify(NotifyRequest) returns (NotifyResponse) {}
 }
 
 // Append a value to a key.
@@ -84,4 +87,12 @@ message SyncResponse {
 message Value {
     repeated string value = 1;
     int64 version = 2;
+}
+
+message NotifyRequest {
+    string key = 1;
+}
+
+message NotifyResponse {
+    bool success = 1;
 }


### PR DESCRIPTION
The followers get and respond to broadcasts, but don't send the
SyncRequests yet.

- The leader updates followers via the Notify RPC.
  - By default this happens for each Update RPC the leader receives.
    This can be overridden with the -brodcast [-frequency MS] flags to
    batch all updates into periodic updates.
- Quality of life
  - Make builds the Go package instead of a list of source files, so now
    we can add other source files without build failures.
  - The readme also says to run via package name.