### PR TITLE
Implement sync procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ protoc -I protos protos/config/config.proto --go_out=plugins=grpc:protos/config
 2. You can start each process with `go run`:
 ```bash
 go run distributed-key-value-store/leader
-go run distributed-key-value-storeer/follower
-go run distributed-key-value-store/client
+go run distributed-key-value-store/follower --follower_id=0
+go run distributed-key-value-store/client --follower_id=0
 ```
 
 # Running with Docker

--- a/protos/follower/follower.proto
+++ b/protos/follower/follower.proto
@@ -67,7 +67,7 @@ message AskFor {
 
 // Contains the current values at a certain version.
 message Mydata {
-    string version = 1;
+    int64 version = 1;
     repeated string values = 2;
 }
 


### PR DESCRIPTION
Running 2 clients at the same time. Each sends 5 requests to the same key. Client-1 starts a little earlier and client-0 starts later. 

Client-0 got all of the 10 messages from the both client at the end. Client-1 got part of the message from client-1 since it starts late so it missing some of the messages, and has to wait for a broad cast.

Test is run manually, so needs further test. 