### PR TITLE
Create a new entry upon receiving a new key from a Notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run in docker, skip to [running with docker](#running-with-docker).
 
 2. Binaries are in bin/.
 
-## Testing
+## Unit Testing
 Enter a foler, then run the test.
 ```bash
 $ cd follower


### PR DESCRIPTION
A key carried by a Notify request may never be seen by the receiver follower. In this case, the follower should also create an entry for the new key and sync with the target follower to retrieve the new data. 